### PR TITLE
Improve message when no results are found and hide load more button

### DIFF
--- a/lib/techschool_web/live/course_live/index.ex
+++ b/lib/techschool_web/live/course_live/index.ex
@@ -54,8 +54,8 @@ defmodule TechschoolWeb.CourseLive.Index do
     |> assign(:search, get_param(params, "search"))
     |> assign(:offset, 0)
     |> assign(:has_more_courses_to_load, has_more_courses_to_load)
-    |> assign(:courses, courses)
     |> assign(:has_courses, !Enum.empty?(courses))
+    |> stream(:courses, courses, reset: true)
     |> noreply()
   end
 
@@ -70,8 +70,8 @@ defmodule TechschoolWeb.CourseLive.Index do
     socket
     |> assign(:offset, offset)
     |> assign(:has_more_courses_to_load, has_more_courses_to_load)
-    |> assign(:courses, courses)
     |> assign(:has_courses, !Enum.empty?(courses))
+    |> stream(:courses, courses, reset: true)
     |> noreply()
   end
 

--- a/lib/techschool_web/live/course_live/index.ex
+++ b/lib/techschool_web/live/course_live/index.ex
@@ -71,7 +71,7 @@ defmodule TechschoolWeb.CourseLive.Index do
     |> assign(:offset, offset)
     |> assign(:has_more_courses_to_load, has_more_courses_to_load)
     |> assign(:has_courses, !Enum.empty?(courses))
-    |> stream(:courses, courses, reset: true)
+    |> stream(:courses, courses)
     |> noreply()
   end
 

--- a/lib/techschool_web/live/course_live/index.ex
+++ b/lib/techschool_web/live/course_live/index.ex
@@ -54,7 +54,7 @@ defmodule TechschoolWeb.CourseLive.Index do
     |> assign(:search, get_param(params, "search"))
     |> assign(:offset, 0)
     |> assign(:has_more_courses_to_load, has_more_courses_to_load)
-    |> stream(:courses, courses, reset: true)
+    |> assign(:courses, courses)
     |> noreply()
   end
 
@@ -69,7 +69,7 @@ defmodule TechschoolWeb.CourseLive.Index do
     socket
     |> assign(:offset, offset)
     |> assign(:has_more_courses_to_load, has_more_courses_to_load)
-    |> stream(:courses, courses)
+    |> assign(:courses, courses)
     |> noreply()
   end
 

--- a/lib/techschool_web/live/course_live/index.ex
+++ b/lib/techschool_web/live/course_live/index.ex
@@ -55,6 +55,7 @@ defmodule TechschoolWeb.CourseLive.Index do
     |> assign(:offset, 0)
     |> assign(:has_more_courses_to_load, has_more_courses_to_load)
     |> assign(:courses, courses)
+    |> assign(:has_courses, !Enum.empty?(courses))
     |> noreply()
   end
 
@@ -70,6 +71,7 @@ defmodule TechschoolWeb.CourseLive.Index do
     |> assign(:offset, offset)
     |> assign(:has_more_courses_to_load, has_more_courses_to_load)
     |> assign(:courses, courses)
+    |> assign(:has_courses, !Enum.empty?(courses))
     |> noreply()
   end
 

--- a/lib/techschool_web/live/course_live/index.html.heex
+++ b/lib/techschool_web/live/course_live/index.html.heex
@@ -9,11 +9,16 @@
     selected_tool={@selected_tool}
   />
   <div class="text-center">
-    <div class="flex flex-wrap justify-center gap-8 md:gap-10" id="courses" phx-update="stream">
-      <.course_card :for={{dom_id, course} <- @streams.courses} id={dom_id} course={course} />
+    <div class="flex flex-wrap justify-center gap-8 md:gap-10" id="courses">
+      <p :if={Enum.empty?(@courses)} id="no-results">
+        No results for the given search
+      </p>
+      <.course_card :for={course <- @courses} id={"course-#{course.id}"} course={course} />
     </div>
-    <.button phx-click="load_more" class="mt-8" disabled={@has_more_courses_to_load == false}>
-      <%= gettext("Load More") %>
-    </.button>
+    <%= if !Enum.empty?(@courses) and @has_more_courses_to_load do %>
+      <.button phx-click="load_more" class="mt-8" disabled={@has_more_courses_to_load == false}>
+        <%= gettext("Load More") %>
+      </.button>
+    <% end %>
   </div>
 </section>

--- a/lib/techschool_web/live/course_live/index.html.heex
+++ b/lib/techschool_web/live/course_live/index.html.heex
@@ -19,10 +19,8 @@
       </div>
     <% end %>
 
-    <%= if @has_courses and @has_more_courses_to_load do %>
-      <.button phx-click="load_more" class="mt-8" disabled={@has_more_courses_to_load == false}>
-        <%= gettext("Load More") %>
-      </.button>
-    <% end %>
+    <.button :if={@has_courses and @has_more_courses_to_load} phx-click="load_more" class="mt-8">
+      <%= gettext("Load More") %>
+    </.button>
   </div>
 </section>

--- a/lib/techschool_web/live/course_live/index.html.heex
+++ b/lib/techschool_web/live/course_live/index.html.heex
@@ -9,12 +9,16 @@
     selected_tool={@selected_tool}
   />
   <div class="text-center">
-    <div class="flex flex-wrap justify-center gap-8 md:gap-10" id="courses">
-      <p :if={!@has_courses} id="no-results">
-        No results for the given search
-      </p>
-      <.course_card :for={course <- @courses} id={"course-#{course.id}"} course={course} />
-    </div>
+    <%= if @has_courses do %>
+      <div class="flex flex-wrap justify-center gap-8 md:gap-10" id="courses" phx-update="stream">
+        <.course_card :for={{dom_id, course} <- @streams.courses} id={dom_id} course={course} />
+      </div>
+    <% else %>
+      <div class="flex flex-wrap justify-center gap-8 md:gap-10">
+        <p>No results for the given search</p>
+      </div>
+    <% end %>
+
     <%= if @has_courses and @has_more_courses_to_load do %>
       <.button phx-click="load_more" class="mt-8" disabled={@has_more_courses_to_load == false}>
         <%= gettext("Load More") %>

--- a/lib/techschool_web/live/course_live/index.html.heex
+++ b/lib/techschool_web/live/course_live/index.html.heex
@@ -10,12 +10,12 @@
   />
   <div class="text-center">
     <div class="flex flex-wrap justify-center gap-8 md:gap-10" id="courses">
-      <p :if={Enum.empty?(@courses)} id="no-results">
+      <p :if={!@has_courses} id="no-results">
         No results for the given search
       </p>
       <.course_card :for={course <- @courses} id={"course-#{course.id}"} course={course} />
     </div>
-    <%= if !Enum.empty?(@courses) and @has_more_courses_to_load do %>
+    <%= if @has_courses and @has_more_courses_to_load do %>
       <.button phx-click="load_more" class="mt-8" disabled={@has_more_courses_to_load == false}>
         <%= gettext("Load More") %>
       </.button>

--- a/test/techschool_web/live/course_live_test.exs
+++ b/test/techschool_web/live/course_live_test.exs
@@ -13,4 +13,36 @@ defmodule TechschoolWeb.CourseLiveTest do
       assert html =~ course.name
     end
   end
+
+  describe "GET /:locale/courses with search query string" do
+    test "must return results when courses are found", %{conn: conn} do
+      channel = channel_fixture()
+      course = course_fixture(channel.youtube_channel_id)
+
+      assert {:ok, _index_live, html} = live(conn, ~p"/en/courses?search=#{course.name}")
+      assert html =~ course.name
+      refute html =~ "Load More"
+    end
+
+    test "must return results when courses are found and show 'Load more' when returns more than 20 results",
+         %{conn: conn} do
+      for _ <- 1..21 do
+        course_fixture(channel_fixture().youtube_channel_id)
+      end
+
+      assert {:ok, _index_live, html} = live(conn, ~p"/en/courses?search=some name")
+      assert html =~ "some name"
+      assert html =~ "Load More"
+    end
+
+    test "must return message 'no results' when courses are not found", %{conn: conn} do
+      channel = channel_fixture()
+      course = course_fixture(channel.youtube_channel_id)
+
+      assert {:ok, _index_live, html} = live(conn, ~p"/en/courses?search=invalid")
+      assert html =~ "No results for the given search"
+      refute html =~ course.name
+      refute html =~ "Load More"
+    end
+  end
 end


### PR DESCRIPTION
## Why is this change being made?

It fixes #35 by adding a friendly message about no results when the filter does not return data

## How is this being accomplished?

- Add a message when no results are returned
- Change from streams to assign
- Hide load more button when no need to show

### Testing

- Run project `iex -S mix phx.server`
- Access http://localhost:4000/en/courses
- Apply some filter
- [ ] Must return results
- Add a search like "wwwwww" and try to filter
- [ ] Must return "no results" message


https://github.com/danielbergholz/techschool.dev/assets/2160392/5e700e29-dd4a-4e1b-8d2d-cb60a1c05280






