### PR TITLE
Fix course loading

### DIFF
--- a/lib/techschool/courses.ex
+++ b/lib/techschool/courses.ex
@@ -30,6 +30,16 @@ defmodule Techschool.Courses do
     |> Enum.map(&add_course_and_channel_urls/1)
   end
 
+  def count_courses(params, locales_available, opts \\ []) do
+    opts =
+      opts
+      |> Keyword.put(:limit, -1)
+      |> Keyword.put(:offset, 0)
+
+    build_search_query(params, locales_available, opts)
+    |> Repo.aggregate(:count, :id)
+  end
+
   defp build_search_query do
     from course in Course,
       preload: [:channel]

--- a/lib/techschool_web/live/course_live/index.ex
+++ b/lib/techschool_web/live/course_live/index.ex
@@ -68,6 +68,7 @@ defmodule TechschoolWeb.CourseLive.Index do
     |> assign(:selected_tool, get_param(params, "tool"))
     |> assign(:selected_fundamentals, get_param(params, "fundamentals"))
     |> assign(:search, get_param(params, "search"))
+    |> assign(:filter_params, params)
     |> assign(:offset, 0)
     |> assign(:has_more_courses_to_load, has_more_courses_to_load)
     |> assign(:has_courses, has_courses)
@@ -80,11 +81,12 @@ defmodule TechschoolWeb.CourseLive.Index do
   end
 
   @impl true
-  def handle_event("load_more", params, socket) do
+  def handle_event("load_more", _params, socket) do
     offset = socket.assigns.offset + 20
+    filter_params = socket.assigns.filter_params
 
-    course_count = Courses.count_courses(params, search_locale(socket))
-    courses = Courses.search_courses(params, search_locale(socket), offset: offset)
+    course_count = Courses.count_courses(filter_params, search_locale(socket))
+    courses = Courses.search_courses(filter_params, search_locale(socket), offset: offset)
 
     has_more_courses_to_load = more_courses_to_load?(courses, course_count, offset)
 


### PR DESCRIPTION
## Why is this change being made?

- There is an edge case where the "Load More" button is incorrectly displayed if course count is divisible by 20
- The "Load More" button breaks the filter because the `handle_event` uses the form params instead of the filter params

## How is this being accomplished?

I added a `count_courses` function that returns the number of courses based on the filter params to calculate if there are more courses to load. I also added the params to the assigns to use the filter params instead of the form params when loading more courses.

In the future, I suggest parsing the filter params using an Ecto schemaless changeset.
