### PR TITLE
Write more LiveView tests

### DIFF
--- a/lib/techschool_web/plugs/set_locale.ex
+++ b/lib/techschool_web/plugs/set_locale.ex
@@ -38,6 +38,8 @@ defmodule TechschoolWeb.Plugs.SetLocale do
     |> check_locale
   end
 
+  def get_available_locales, do: @available_locales
+
   defp check_locale(locale) when locale in @available_locales, do: locale
   defp check_locale(_), do: nil
 end

--- a/test/techschool_web/live/bootcamp_live_test.exs
+++ b/test/techschool_web/live/bootcamp_live_test.exs
@@ -17,11 +17,11 @@ defmodule TechschoolWeb.BootcampLiveTest do
   end
 
   describe "GET /:locale/bootcamps/:slug" do
-    test "lists all lessons from a bootcamp", %{conn: conn} do
-      lesson = lesson_fixture()
-      bootcamp = bootcamp_fixture(lesson_names: [lesson.name])
-
-      for locale <- SetLocale.get_available_locales() do
+    for locale <- SetLocale.get_available_locales() do
+      @tag locale: locale
+      test "lists all lessons from a bootcamp for #{locale} locale", %{conn: conn, locale: locale} do
+        lesson = lesson_fixture()
+        bootcamp = bootcamp_fixture(lesson_names: [lesson.name])
         description_variant = "description_#{locale}" |> String.to_atom()
         {:ok, _bootcamp_live, html} = live(conn, ~p"/#{locale}/bootcamps/#{bootcamp.slug}")
         bootcamp_description = Map.get(bootcamp, description_variant)

--- a/test/techschool_web/live/bootcamp_live_test.exs
+++ b/test/techschool_web/live/bootcamp_live_test.exs
@@ -5,6 +5,8 @@ defmodule TechschoolWeb.BootcampLiveTest do
   import Techschool.BootcampsFixtures
   import Techschool.LessonsFixtures
 
+  alias TechschoolWeb.Plugs.SetLocale
+
   describe "GET /:locale/bootcamps" do
     test "lists all bootcamps", %{conn: conn} do
       bootcamp = bootcamp_fixture()
@@ -19,9 +21,13 @@ defmodule TechschoolWeb.BootcampLiveTest do
       lesson = lesson_fixture()
       bootcamp = bootcamp_fixture(lesson_names: [lesson.name])
 
-      assert {:ok, _bootcamp_live, html} = live(conn, ~p"/en/bootcamps/#{bootcamp.slug}")
-      assert html =~ bootcamp.name
-      assert html =~ lesson.description_en
+      for locale <- SetLocale.get_available_locales() do
+        description_variant = "description_#{locale}" |> String.to_atom()
+        {:ok, _bootcamp_live, html} = live(conn, ~p"/#{locale}/bootcamps/#{bootcamp.slug}")
+        bootcamp_description = Map.get(bootcamp, description_variant)
+        assert html =~ bootcamp.name
+        assert html =~ bootcamp_description
+      end
     end
   end
 end

--- a/test/techschool_web/live/course_live_test.exs
+++ b/test/techschool_web/live/course_live_test.exs
@@ -4,15 +4,22 @@ defmodule TechschoolWeb.CourseLiveTest do
   import Phoenix.LiveViewTest
   import Techschool.{CoursesFixtures, ChannelsFixtures, PlatformsFixtures}
 
+  alias TechschoolWeb.Plugs.SetLocale
+
   describe "GET /:locale/courses" do
     test "lists all courses and platforms", %{conn: conn} do
       channel = channel_fixture()
       course = course_fixture(channel.youtube_channel_id)
       platform = platform_fixture()
 
-      assert {:ok, _index_live, html} = live(conn, ~p"/en/courses")
-      assert html =~ course.name
-      assert html =~ platform.name
+      for locale <- SetLocale.get_available_locales() do
+        description_variant = "description_#{locale}"
+        {:ok, _index_live, html} = live(conn, "/#{locale}/courses")
+        description = Map.get(platform, String.to_atom(description_variant))
+        assert html =~ description
+        assert html =~ course.name
+        assert html =~ platform.name
+      end
     end
   end
 

--- a/test/techschool_web/live/course_live_test.exs
+++ b/test/techschool_web/live/course_live_test.exs
@@ -13,10 +13,10 @@ defmodule TechschoolWeb.CourseLiveTest do
       platform = platform_fixture()
 
       for locale <- SetLocale.get_available_locales() do
-        description_variant = "description_#{locale}"
-        {:ok, _index_live, html} = live(conn, "/#{locale}/courses")
-        description = Map.get(platform, String.to_atom(description_variant))
-        assert html =~ description
+        description_variant = "description_#{locale}" |> String.to_atom()
+        {:ok, _index_live, html} = live(conn, ~p"/#{locale}/courses")
+        platform_description = Map.get(platform, description_variant)
+        assert html =~ platform_description
         assert html =~ course.name
         assert html =~ platform.name
       end

--- a/test/techschool_web/live/course_live_test.exs
+++ b/test/techschool_web/live/course_live_test.exs
@@ -7,12 +7,12 @@ defmodule TechschoolWeb.CourseLiveTest do
   alias TechschoolWeb.Plugs.SetLocale
 
   describe "GET /:locale/courses" do
-    test "lists all courses and platforms", %{conn: conn} do
-      channel = channel_fixture()
-      course = course_fixture(channel.youtube_channel_id)
-      platform = platform_fixture()
-
-      for locale <- SetLocale.get_available_locales() do
+    for locale <- SetLocale.get_available_locales() do
+      @tag locale: locale
+      test "lists all courses and platforms for #{locale} locale", %{conn: conn, locale: locale} do
+        channel = channel_fixture()
+        course = course_fixture(channel.youtube_channel_id)
+        platform = platform_fixture()
         description_variant = "description_#{locale}" |> String.to_atom()
         {:ok, _index_live, html} = live(conn, ~p"/#{locale}/courses")
         platform_description = Map.get(platform, description_variant)


### PR DESCRIPTION
Related to issue https://github.com/danielbergholz/techschool.dev/issues/66

Hey, @danielbergholz! I added some test for courses and bootcamps in different locales. There is no need to explicitly write tested locale anymore.
Test for filtering will appear soon. :rocket:

I guess, it is possible to move the whole `for` block to macro, called something like `test_for_locale`. I'll try to figure it out :smile:
