### PR TITLE
Add count for current users online

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ npm-debug.log
 .env
 
 .elixir_ls/
+
+.tool-versions

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.17.0
+erlang 26.1.2

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,0 @@
-elixir 1.17.0
-erlang 26.1.2

--- a/lib/techschool/application.ex
+++ b/lib/techschool/application.ex
@@ -23,7 +23,8 @@ defmodule Techschool.Application do
       # {Techschool.Worker, arg},
       # Start to serve requests, typically the last entry
       TechschoolWeb.Endpoint,
-      {Cachex, name: :techschool_cache}
+      {Cachex, name: :techschool_cache},
+      TechschoolWeb.Presence
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/techschool_web.ex
+++ b/lib/techschool_web.ex
@@ -89,6 +89,7 @@ defmodule TechschoolWeb do
       import Phoenix.HTML
       # Core UI components and translation
       import TechschoolWeb.CoreComponents
+      import TechschoolWeb.OnlineUsers
       import TechschoolWeb.Gettext
 
       # Shortcut for generating JS commands

--- a/lib/techschool_web/components/online_users.ex
+++ b/lib/techschool_web/components/online_users.ex
@@ -6,46 +6,24 @@ defmodule TechschoolWeb.OnlineUsers do
 
   attr :count, :integer, required: true
 
-  def show_online_users(%{count: 0} = assigns) do
-    ~H"""
-    """
-  end
-
-  def show_online_users(%{count: 1} = assigns) do
-    ~H"""
-    <span id="online_users_count" class="mt-2 relative inline-flex">
-      <button
-        type="button"
-        class="inline-flex items-center px-4 py-2 font-semibold leading-6 text-sm shadow rounded-md text-green bg-white dark:bg-slate-800 transition ease-in-out duration-150 cursor-not-allowed ring-1 ring-slate-900/10 dark:ring-slate-200/20"
-        disabled=""
-      >
-        <%= @count %> online user
-      </button>
-      <span class="flex absolute h-3 w-3 top-0 right-0 -mt-1 -mr-1">
-        <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-green opacity-75">
-        </span>
-        <span class="relative inline-flex rounded-full h-3 w-3 bg-green"></span>
-      </span>
-    </span>
-    """
-  end
+  def show_online_users(%{count: 0} = assigns), do: ~H""
 
   def show_online_users(assigns) do
     ~H"""
-    <span id="online_users_count" class="mt-2 relative inline-flex">
-      <button
-        type="button"
-        class="inline-flex items-center px-4 py-2 font-semibold leading-6 text-sm shadow rounded-md text-green bg-white dark:bg-slate-800 transition ease-in-out duration-150 cursor-not-allowed ring-1 ring-slate-900/10 dark:ring-slate-200/20"
-        disabled=""
-      >
-        <%= @count %> online users
-      </button>
+    <div
+      id="online_users_count"
+      class="mt-2 relative inline-flex"
+      aria-label="Number of online users using TechSchool"
+    >
+      <p class="px-4 py-2 font-semibold text-sm rounded-md text-green bg-slate-800">
+        <%= @count %> user<%= if @count == 1, do: "", else: "s" %> online
+      </p>
       <span class="flex absolute h-3 w-3 top-0 right-0 -mt-1 -mr-1">
         <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-green opacity-75">
         </span>
         <span class="relative inline-flex rounded-full h-3 w-3 bg-green"></span>
       </span>
-    </span>
+    </div>
     """
   end
 end

--- a/lib/techschool_web/components/online_users.ex
+++ b/lib/techschool_web/components/online_users.ex
@@ -1,0 +1,51 @@
+defmodule TechschoolWeb.OnlineUsers do
+  @moduledoc """
+  Component to show the count of online users.
+  """
+  use Phoenix.Component
+
+  attr :count, :integer, required: true
+
+  def show_online_users(%{count: 0} = assigns) do
+    ~H"""
+    """
+  end
+
+  def show_online_users(%{count: 1} = assigns) do
+    ~H"""
+    <span id="online_users_count" class="mt-2 relative inline-flex">
+      <button
+        type="button"
+        class="inline-flex items-center px-4 py-2 font-semibold leading-6 text-sm shadow rounded-md text-green bg-white dark:bg-slate-800 transition ease-in-out duration-150 cursor-not-allowed ring-1 ring-slate-900/10 dark:ring-slate-200/20"
+        disabled=""
+      >
+        <%= @count %> online user
+      </button>
+      <span class="flex absolute h-3 w-3 top-0 right-0 -mt-1 -mr-1">
+        <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-green opacity-75">
+        </span>
+        <span class="relative inline-flex rounded-full h-3 w-3 bg-green"></span>
+      </span>
+    </span>
+    """
+  end
+
+  def show_online_users(assigns) do
+    ~H"""
+    <span id="online_users_count" class="mt-2 relative inline-flex">
+      <button
+        type="button"
+        class="inline-flex items-center px-4 py-2 font-semibold leading-6 text-sm shadow rounded-md text-green bg-white dark:bg-slate-800 transition ease-in-out duration-150 cursor-not-allowed ring-1 ring-slate-900/10 dark:ring-slate-200/20"
+        disabled=""
+      >
+        <%= @count %> online users
+      </button>
+      <span class="flex absolute h-3 w-3 top-0 right-0 -mt-1 -mr-1">
+        <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-green opacity-75">
+        </span>
+        <span class="relative inline-flex rounded-full h-3 w-3 bg-green"></span>
+      </span>
+    </span>
+    """
+  end
+end

--- a/lib/techschool_web/live/bootcamp_live/index.ex
+++ b/lib/techschool_web/live/bootcamp_live/index.ex
@@ -3,6 +3,7 @@ defmodule TechschoolWeb.BootcampLive.Index do
 
   alias Techschool.Bootcamps
   alias Techschool.Bootcamps.Bootcamp
+  alias TechschoolWeb.OnlineUsersCounter
 
   embed_templates "components/*"
 
@@ -13,6 +14,12 @@ defmodule TechschoolWeb.BootcampLive.Index do
 
   @impl true
   def mount(_params, _session, socket) do
+    if connected?(socket) do
+      Phoenix.PubSub.subscribe(Techschool.PubSub, OnlineUsersCounter.online_users_topic())
+
+      OnlineUsersCounter.track_online_user()
+    end
+
     socket
     |> assign(:page_title, "Bootcamps | TechSchool")
     |> assign(
@@ -21,7 +28,13 @@ defmodule TechschoolWeb.BootcampLive.Index do
         "TechSchool offers a variety of bootcamps to help you learn the skills you need to start a new career in tech."
       )
     )
+    |> assign(:online_users_count, 0)
     |> stream(:bootcamps, Bootcamps.list_bootcamps(), reset: true)
     |> ok()
+  end
+
+  @impl true
+  def handle_info(%Phoenix.Socket.Broadcast{} = _event, socket) do
+    {:noreply, assign(socket, :online_users_count, OnlineUsersCounter.get_online_users_count())}
   end
 end

--- a/lib/techschool_web/live/bootcamp_live/index.ex
+++ b/lib/techschool_web/live/bootcamp_live/index.ex
@@ -35,6 +35,8 @@ defmodule TechschoolWeb.BootcampLive.Index do
 
   @impl true
   def handle_info(%Phoenix.Socket.Broadcast{} = _event, socket) do
-    {:noreply, assign(socket, :online_users_count, OnlineUsersCounter.get_online_users_count())}
+    socket
+    |> assign(:online_users_count, OnlineUsersCounter.get_online_users_count())
+    |> noreply()
   end
 end

--- a/lib/techschool_web/live/bootcamp_live/show.ex
+++ b/lib/techschool_web/live/bootcamp_live/show.ex
@@ -3,6 +3,7 @@ defmodule TechschoolWeb.BootcampLive.Show do
 
   alias Techschool.Bootcamps
   alias Techschool.Lessons.Lesson
+  alias TechschoolWeb.OnlineUsersCounter
 
   embed_templates "components/*"
 
@@ -14,6 +15,12 @@ defmodule TechschoolWeb.BootcampLive.Show do
 
   @impl true
   def mount(params, _session, socket) do
+    if connected?(socket) do
+      Phoenix.PubSub.subscribe(Techschool.PubSub, OnlineUsersCounter.online_users_topic())
+
+      OnlineUsersCounter.track_online_user()
+    end
+
     bootcamp = Bootcamps.get_bootcamp_by_slug!(params["slug"])
     locale = socket.assigns.locale
 
@@ -28,6 +35,11 @@ defmodule TechschoolWeb.BootcampLive.Show do
     )
     |> assign(:bootcamp, bootcamp)
     |> ok()
+  end
+
+  @impl true
+  def handle_info(%Phoenix.Socket.Broadcast{} = _event, socket) do
+    {:noreply, assign(socket, :online_users_count, OnlineUsersCounter.get_online_users_count())}
   end
 
   def build_lesson_url(locale, lesson) do

--- a/lib/techschool_web/live/bootcamp_live/show.ex
+++ b/lib/techschool_web/live/bootcamp_live/show.ex
@@ -39,7 +39,9 @@ defmodule TechschoolWeb.BootcampLive.Show do
 
   @impl true
   def handle_info(%Phoenix.Socket.Broadcast{} = _event, socket) do
-    {:noreply, assign(socket, :online_users_count, OnlineUsersCounter.get_online_users_count())}
+    socket
+    |> assign(:online_users_count, OnlineUsersCounter.get_online_users_count())
+    |> noreply()
   end
 
   def build_lesson_url(locale, lesson) do

--- a/lib/techschool_web/live/course_live/index.ex
+++ b/lib/techschool_web/live/course_live/index.ex
@@ -115,7 +115,9 @@ defmodule TechschoolWeb.CourseLive.Index do
 
   @impl true
   def handle_info(%Phoenix.Socket.Broadcast{} = _event, socket) do
-    {:noreply, assign(socket, :online_users_count, OnlineUsersCounter.get_online_users_count())}
+    socket
+    |> assign(:online_users_count, OnlineUsersCounter.get_online_users_count())
+    |> noreply()
   end
 
   defp build_url(%{assigns: %{locale: locale}}, params) do

--- a/lib/techschool_web/live/page_live/home.ex
+++ b/lib/techschool_web/live/page_live/home.ex
@@ -35,6 +35,8 @@ defmodule TechschoolWeb.PageLive.Home do
 
   @impl true
   def handle_info(%Phoenix.Socket.Broadcast{} = _event, socket) do
-    {:noreply, assign(socket, :online_users_count, OnlineUsersCounter.get_online_users_count())}
+    socket
+    |> assign(:online_users_count, OnlineUsersCounter.get_online_users_count())
+    |> noreply()
   end
 end

--- a/lib/techschool_web/live/page_live/home.ex
+++ b/lib/techschool_web/live/page_live/home.ex
@@ -2,6 +2,7 @@ defmodule TechschoolWeb.PageLive.Home do
   use TechschoolWeb, :live_view
 
   alias Techschool.GitHub
+  alias TechschoolWeb.OnlineUsersCounter
 
   embed_templates "components/*"
 
@@ -17,11 +18,23 @@ defmodule TechschoolWeb.PageLive.Home do
 
   @impl true
   def mount(_params, _session, socket) do
+    if connected?(socket) do
+      Phoenix.PubSub.subscribe(Techschool.PubSub, "online_users")
+
+      OnlineUsersCounter.track_online_user()
+    end
+
     socket
     |> assign_async(:github_contributors, fn ->
       {:ok, %{github_contributors: GitHub.get_contributors()}}
     end)
     |> assign(:page_title, "TechSchool")
+    |> assign(:online_users, 0)
     |> ok()
+  end
+
+  @impl true
+  def handle_info(%Phoenix.Socket.Broadcast{} = _event, socket) do
+    {:noreply, assign(socket, :online_users, OnlineUsersCounter.get_online_users_count())}
   end
 end

--- a/lib/techschool_web/live/page_live/home.ex
+++ b/lib/techschool_web/live/page_live/home.ex
@@ -19,7 +19,7 @@ defmodule TechschoolWeb.PageLive.Home do
   @impl true
   def mount(_params, _session, socket) do
     if connected?(socket) do
-      Phoenix.PubSub.subscribe(Techschool.PubSub, "online_users")
+      Phoenix.PubSub.subscribe(Techschool.PubSub, OnlineUsersCounter.online_users_topic())
 
       OnlineUsersCounter.track_online_user()
     end
@@ -29,12 +29,12 @@ defmodule TechschoolWeb.PageLive.Home do
       {:ok, %{github_contributors: GitHub.get_contributors()}}
     end)
     |> assign(:page_title, "TechSchool")
-    |> assign(:online_users, 0)
+    |> assign(:online_users_count, 0)
     |> ok()
   end
 
   @impl true
   def handle_info(%Phoenix.Socket.Broadcast{} = _event, socket) do
-    {:noreply, assign(socket, :online_users, OnlineUsersCounter.get_online_users_count())}
+    {:noreply, assign(socket, :online_users_count, OnlineUsersCounter.get_online_users_count())}
   end
 end

--- a/lib/techschool_web/live/page_live/home.html.heex
+++ b/lib/techschool_web/live/page_live/home.html.heex
@@ -8,6 +8,7 @@
         <h2 class="text-gray mt-2 md:text-lg text-base">
           <%= gettext("Go from zero to your first job without any financial loss") %>
         </h2>
+        <.show_online_users count={@online_users_count} />
         <.translate_button inverse_locale={inverse_locale(@locale)} />
       </div>
       <img

--- a/lib/techschool_web/live/page_live/home.html.heex
+++ b/lib/techschool_web/live/page_live/home.html.heex
@@ -9,20 +9,6 @@
           <%= gettext("Go from zero to your first job without any financial loss") %>
         </h2>
         <.translate_button inverse_locale={inverse_locale(@locale)} />
-        <span id="online_users_count" class="mt-2 relative inline-flex">
-          <button
-            type="button"
-            class="inline-flex items-center px-4 py-2 font-semibold leading-6 text-sm shadow rounded-md text-green bg-white dark:bg-slate-800 transition ease-in-out duration-150 cursor-not-allowed ring-1 ring-slate-900/10 dark:ring-slate-200/20"
-            disabled=""
-          >
-            <%= @online_users_count %>
-          </button>
-          <span class="flex absolute h-3 w-3 top-0 right-0 -mt-1 -mr-1">
-            <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-green opacity-75">
-            </span>
-            <span class="relative inline-flex rounded-full h-3 w-3 bg-green"></span>
-          </span>
-        </span>
       </div>
       <img
         src="https://ucarecdn.com/50caadda-a024-4fce-a168-0e463f695f93/"

--- a/lib/techschool_web/live/page_live/home.html.heex
+++ b/lib/techschool_web/live/page_live/home.html.heex
@@ -9,6 +9,20 @@
           <%= gettext("Go from zero to your first job without any financial loss") %>
         </h2>
         <.translate_button inverse_locale={inverse_locale(@locale)} />
+        <span id="online_users_count" class="mt-2 relative inline-flex">
+          <button
+            type="button"
+            class="inline-flex items-center px-4 py-2 font-semibold leading-6 text-sm shadow rounded-md text-green bg-white dark:bg-slate-800 transition ease-in-out duration-150 cursor-not-allowed ring-1 ring-slate-900/10 dark:ring-slate-200/20"
+            disabled=""
+          >
+            <%= @online_users_count %>
+          </button>
+          <span class="flex absolute h-3 w-3 top-0 right-0 -mt-1 -mr-1">
+            <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-green opacity-75">
+            </span>
+            <span class="relative inline-flex rounded-full h-3 w-3 bg-green"></span>
+          </span>
+        </span>
       </div>
       <img
         src="https://ucarecdn.com/50caadda-a024-4fce-a168-0e463f695f93/"

--- a/lib/techschool_web/online_users_counter.ex
+++ b/lib/techschool_web/online_users_counter.ex
@@ -1,0 +1,33 @@
+defmodule TechschoolWeb.OnlineUsersCounter do
+  @moduledoc """
+  This module provides topics shared among the application
+  """
+
+  alias TechschoolWeb.Presence
+
+  require Logger
+
+  @online_users_topic "online_users_topic"
+
+  def track_online_user do
+    {:ok, _ref} =
+      case Presence.track(
+             self(),
+             @online_users_topic,
+             "user:#{Ecto.UUID.generate()}",
+             %{}
+           ) do
+        {:ok, ref} ->
+          {:ok, ref}
+
+        _ ->
+          Logger.warning("Not possible to track a online user")
+      end
+  end
+
+  def get_online_users_count do
+    @online_users_topic
+    |> Presence.list()
+    |> map_size()
+  end
+end

--- a/lib/techschool_web/online_users_counter.ex
+++ b/lib/techschool_web/online_users_counter.ex
@@ -9,6 +9,8 @@ defmodule TechschoolWeb.OnlineUsersCounter do
 
   @online_users_topic "online_users_topic"
 
+  def online_users_topic, do: @online_users_topic
+
   def track_online_user do
     {:ok, _ref} =
       case Presence.track(
@@ -21,7 +23,7 @@ defmodule TechschoolWeb.OnlineUsersCounter do
           {:ok, ref}
 
         _ ->
-          Logger.warning("Not possible to track a online user")
+          Logger.warning("Not possible to track online user")
       end
   end
 

--- a/lib/techschool_web/presence.ex
+++ b/lib/techschool_web/presence.ex
@@ -1,0 +1,9 @@
+defmodule TechschoolWeb.Presence do
+  @moduledoc """
+  Module TechschoolWeb.Presence
+  """
+
+  use Phoenix.Presence,
+    otp_app: :techschool,
+    pubsub_server: Techschool.PubSub
+end

--- a/test/techschool_web/components/online_users_test.exs
+++ b/test/techschool_web/components/online_users_test.exs
@@ -27,7 +27,7 @@ defmodule TechschoolWeb.OnlineUsersTest do
       rendered_component_html = render_component(&OnlineUsers.show_online_users/1, assigns)
 
       assert rendered_component_html =~
-               ~s(<span id=\"online_users_count\" class=\"mt-2 relative inline-flex\">\n  <button type=\"button\" class=\"inline-flex items-center px-4 py-2 font-semibold leading-6 text-sm shadow rounded-md text-green bg-white dark:bg-slate-800 transition ease-in-out duration-150 cursor-not-allowed ring-1 ring-slate-900/10 dark:ring-slate-200/20\" disabled=\"\">\n    2 online users\n  </button>\n  <span class=\"flex absolute h-3 w-3 top-0 right-0 -mt-1 -mr-1\">\n    <span class=\"animate-ping absolute inline-flex h-full w-full rounded-full bg-green opacity-75\">\n    </span>\n    <span class=\"relative inline-flex rounded-full h-3 w-3 bg-green\"></span>\n  </span>\n</span>)
+               ~s(<div id=\"online_users_count\" class=\"mt-2 relative inline-flex\" aria-label=\"Number of online users using TechSchool\">\n  <p class=\"px-4 py-2 font-semibold text-sm rounded-md text-green bg-slate-800\">\n    2 users online\n  </p>\n  <span class=\"flex absolute h-3 w-3 top-0 right-0 -mt-1 -mr-1\">\n    <span class=\"animate-ping absolute inline-flex h-full w-full rounded-full bg-green opacity-75\">\n    </span>\n    <span class=\"relative inline-flex rounded-full h-3 w-3 bg-green\"></span>\n  </span>\n</div>)
     end
   end
 end

--- a/test/techschool_web/components/online_users_test.exs
+++ b/test/techschool_web/components/online_users_test.exs
@@ -20,7 +20,7 @@ defmodule TechschoolWeb.OnlineUsersTest do
       rendered_component_html = render_component(&OnlineUsers.show_online_users/1, assigns)
 
       assert rendered_component_html =~
-               ~s(<span id=\"online_users_count\" class=\"mt-2 relative inline-flex\">\n  <button type=\"button\" class=\"inline-flex items-center px-4 py-2 font-semibold leading-6 text-sm shadow rounded-md text-green bg-white dark:bg-slate-800 transition ease-in-out duration-150 cursor-not-allowed ring-1 ring-slate-900/10 dark:ring-slate-200/20\" disabled=\"\">\n    1 online user\n  </button>\n  <span class=\"flex absolute h-3 w-3 top-0 right-0 -mt-1 -mr-1\">\n    <span class=\"animate-ping absolute inline-flex h-full w-full rounded-full bg-green opacity-75\">\n    </span>\n    <span class=\"relative inline-flex rounded-full h-3 w-3 bg-green\"></span>\n  </span>\n</span>)
+               ~s(<div id=\"online_users_count\" class=\"mt-2 relative inline-flex\" aria-label=\"Number of online users using TechSchool\">\n  <p class=\"px-4 py-2 font-semibold text-sm rounded-md text-green bg-slate-800\">\n    1 user online\n  </p>\n  <span class=\"flex absolute h-3 w-3 top-0 right-0 -mt-1 -mr-1\">\n    <span class=\"animate-ping absolute inline-flex h-full w-full rounded-full bg-green opacity-75\">\n    </span>\n    <span class=\"relative inline-flex rounded-full h-3 w-3 bg-green\"></span>\n  </span>\n</div>)
 
       assigns = %{count: 2}
 

--- a/test/techschool_web/components/online_users_test.exs
+++ b/test/techschool_web/components/online_users_test.exs
@@ -1,0 +1,33 @@
+defmodule TechschoolWeb.OnlineUsersTest do
+  use TechschoolWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias TechschoolWeb.OnlineUsers
+
+  describe "show_online_users/1" do
+    test "do not render component when count is 0 (edge case)" do
+      assigns = %{count: 0}
+
+      rendered_component_html = render_component(&OnlineUsers.show_online_users/1, assigns)
+
+      assert rendered_component_html =~ ""
+    end
+
+    test "renders online users count singular and plural form" do
+      assigns = %{count: 1}
+
+      rendered_component_html = render_component(&OnlineUsers.show_online_users/1, assigns)
+
+      assert rendered_component_html =~
+               ~s(<span id=\"online_users_count\" class=\"mt-2 relative inline-flex\">\n  <button type=\"button\" class=\"inline-flex items-center px-4 py-2 font-semibold leading-6 text-sm shadow rounded-md text-green bg-white dark:bg-slate-800 transition ease-in-out duration-150 cursor-not-allowed ring-1 ring-slate-900/10 dark:ring-slate-200/20\" disabled=\"\">\n    1 online user\n  </button>\n  <span class=\"flex absolute h-3 w-3 top-0 right-0 -mt-1 -mr-1\">\n    <span class=\"animate-ping absolute inline-flex h-full w-full rounded-full bg-green opacity-75\">\n    </span>\n    <span class=\"relative inline-flex rounded-full h-3 w-3 bg-green\"></span>\n  </span>\n</span>)
+
+      assigns = %{count: 2}
+
+      rendered_component_html = render_component(&OnlineUsers.show_online_users/1, assigns)
+
+      assert rendered_component_html =~
+               ~s(<span id=\"online_users_count\" class=\"mt-2 relative inline-flex\">\n  <button type=\"button\" class=\"inline-flex items-center px-4 py-2 font-semibold leading-6 text-sm shadow rounded-md text-green bg-white dark:bg-slate-800 transition ease-in-out duration-150 cursor-not-allowed ring-1 ring-slate-900/10 dark:ring-slate-200/20\" disabled=\"\">\n    2 online users\n  </button>\n  <span class=\"flex absolute h-3 w-3 top-0 right-0 -mt-1 -mr-1\">\n    <span class=\"animate-ping absolute inline-flex h-full w-full rounded-full bg-green opacity-75\">\n    </span>\n    <span class=\"relative inline-flex rounded-full h-3 w-3 bg-green\"></span>\n  </span>\n</span>)
+    end
+  end
+end

--- a/test/techschool_web/live/page_live_test.exs
+++ b/test/techschool_web/live/page_live_test.exs
@@ -5,8 +5,10 @@ defmodule TechschoolWeb.PageLiveTest do
 
   describe "GET /:locale" do
     test "Returns 200 status code", %{conn: conn} do
-      assert {:ok, _home_live, html} = live(conn, ~p"/en")
+      assert {:ok, view, html} = live(conn, ~p"/en")
       assert html =~ "TechSchool"
+
+      assert has_element?(view, "#online_users_count", "1")
     end
   end
 end

--- a/test/techschool_web/live/page_live_test.exs
+++ b/test/techschool_web/live/page_live_test.exs
@@ -5,10 +5,8 @@ defmodule TechschoolWeb.PageLiveTest do
 
   describe "GET /:locale" do
     test "Returns 200 status code", %{conn: conn} do
-      assert {:ok, view, html} = live(conn, ~p"/en")
+      assert {:ok, _view, html} = live(conn, ~p"/en")
       assert html =~ "TechSchool"
-
-      assert has_element?(view, "#online_users_count", "1")
     end
   end
 end

--- a/test/techschool_web/live/page_live_test.exs
+++ b/test/techschool_web/live/page_live_test.exs
@@ -5,8 +5,10 @@ defmodule TechschoolWeb.PageLiveTest do
 
   describe "GET /:locale" do
     test "Returns 200 status code", %{conn: conn} do
-      assert {:ok, _view, html} = live(conn, ~p"/en")
+      assert {:ok, view, html} = live(conn, ~p"/en")
       assert html =~ "TechSchool"
+
+      assert has_element?(view, "#online_users_count", "1")
     end
   end
 end

--- a/test/techschool_web/online_users_counter_test.exs
+++ b/test/techschool_web/online_users_counter_test.exs
@@ -1,0 +1,23 @@
+defmodule TechschoolWeb.OnlineUsersCounterTest do
+  use Techschool.DataCase
+  alias TechschoolWeb.OnlineUsersCounter
+
+  describe "track_online_user/0" do
+    test "must track a new user" do
+      assert {:ok, _} = OnlineUsersCounter.track_online_user()
+    end
+  end
+
+  describe "get_online_users_count/0" do
+    test "return 0" do
+      assert OnlineUsersCounter.get_online_users_count() == 0
+    end
+
+    test "must return 2" do
+      OnlineUsersCounter.track_online_user()
+      OnlineUsersCounter.track_online_user()
+
+      assert OnlineUsersCounter.get_online_users_count() == 2
+    end
+  end
+end


### PR DESCRIPTION
## Why is this change being made?

Adds #79 

## How is this being accomplished?

It adds a counter based on the amount of users accessing the website. This was done using Presence from Phoenix to handle the whole behavior.

Every LV module on the mount will trigger the Presence and a component on the home page will render the proper value.

![Screenshot from 2024-07-22 18-21-16](https://github.com/user-attachments/assets/58040632-1870-482e-8b10-e2d7cd076385)

## Testing

- Run the project
- Access the home page
- [ ] Must show the value of total online users
- Open a anon browser and access a new page
- [ ] It must update the value for the count

## Take aways

- UI is not my strongest skill so any suggestion or commit would be helpful
- There is a couple of copy and paste code, I do not see as a problem now, but in future that can be improved
