### PR TITLE
test: validating JSON files

### DIFF
--- a/test/support/json_validation.ex
+++ b/test/support/json_validation.ex
@@ -1,0 +1,37 @@
+defmodule Techschool.JSONValidator do
+  @moduledoc """
+  This module is used to validate the priv/repo/data files.
+  """
+  defmacro __using__(opts) do
+    path = opts[:path]
+    types = opts[:types]
+    required = opts[:required]
+
+    quote do
+      import Ecto.Changeset
+
+      def get_json() do
+        unquote(path)
+        |> File.read!()
+        |> Jason.decode!(keys: :atoms)
+      end
+
+      def as_changeset(item) do
+        keys = Map.keys(unquote(types))
+        required = unquote(required)
+
+        required = if(required, do: required, else: keys)
+
+        {%{}, unquote(types)}
+        |> cast(item, keys)
+        |> validate_required(required)
+      end
+
+      def validate(item) do
+        assert %{valid?: true} = as_changeset(item)
+      end
+
+      defoverridable validate: 1
+    end
+  end
+end

--- a/test/techschool/bootcamps_json_test.exs
+++ b/test/techschool/bootcamps_json_test.exs
@@ -1,0 +1,24 @@
+defmodule Techschool.BootcampsJSONTest do
+  use ExUnit.Case
+
+  use Techschool.JSONValidator,
+    path: "priv/repo/data/bootcamps.json",
+    types: %{
+      name: :string,
+      image_url: :string,
+      description_en: :string,
+      description_pt: :string,
+      lesson_names: {:array, :string}
+    },
+    required: [:name, :image_url, :description_en, :description_pt]
+
+  setup_all do
+    {:ok, bootcamps: get_json()}
+  end
+
+  describe "bootcamps JSON validation" do
+    test "validates priv/repo/data/bootcamps.json file", %{bootcamps: bootcamps} do
+      assert Enum.all?(bootcamps, &validate/1)
+    end
+  end
+end

--- a/test/techschool/channels_json_test.exs
+++ b/test/techschool/channels_json_test.exs
@@ -1,0 +1,22 @@
+defmodule Techschool.ChannelsJSONTest do
+  use ExUnit.Case
+
+  use Techschool.JSONValidator,
+    path: "priv/repo/data/channels.json",
+    types: %{
+      name: :string,
+      image_url: :string,
+      youtube_channel_id: :string
+    },
+    required: [:name, :image_url, :youtube_channel_id]
+
+  setup_all do
+    {:ok, channels: get_json()}
+  end
+
+  describe "channels JSON validation" do
+    test "validates priv/repo/data/channels.json file", %{channels: channels} do
+      assert Enum.all?(channels, &validate/1)
+    end
+  end
+end

--- a/test/techschool/courses_json_test.exs
+++ b/test/techschool/courses_json_test.exs
@@ -1,0 +1,36 @@
+defmodule Techschool.CoursesJSONTest do
+  use ExUnit.Case
+
+  use Techschool.JSONValidator,
+    path: "priv/repo/data/courses.json",
+    types: %{
+      name: :string,
+      youtube_course_id: :string,
+      type: :string,
+      locale: :string,
+      image_url: :string,
+      published_at: :string,
+      language_names: {:array, :string},
+      framework_names: {:array, :string},
+      tool_names: {:array, :string},
+      fundamentals_names: {:array, :string}
+    },
+    required: [
+      :name,
+      :image_url,
+      :locale,
+      :type,
+      :published_at,
+      :youtube_course_id
+    ]
+
+  setup_all do
+    {:ok, courses: get_json()}
+  end
+
+  describe "courses JSON validation" do
+    test "validates priv/repo/data/courses.json file", %{courses: courses} do
+      assert Enum.all?(courses, &validate/1)
+    end
+  end
+end

--- a/test/techschool/frameworks_json_test.exs
+++ b/test/techschool/frameworks_json_test.exs
@@ -1,0 +1,18 @@
+defmodule Techschool.FrameworksJSONTest do
+  use ExUnit.Case
+
+  use Techschool.JSONValidator,
+    path: "priv/repo/data/frameworks.json",
+    types: %{name: :string, image_url: :string},
+    required: [:name]
+
+  setup_all do
+    {:ok, frameworks: get_json()}
+  end
+
+  describe "frameworks JSON validation" do
+    test "validates priv/repo/data/frameworks.json file", %{frameworks: frameworks} do
+      assert Enum.all?(frameworks, &validate/1)
+    end
+  end
+end

--- a/test/techschool/fundamentals_json_test.exs
+++ b/test/techschool/fundamentals_json_test.exs
@@ -1,0 +1,21 @@
+defmodule Techschool.FundamentalsJSONTest do
+  use ExUnit.Case
+
+  use Techschool.JSONValidator,
+    path: "priv/repo/data/fundamentals.json",
+    types: %{
+      name: :string,
+      image_url: :string
+    },
+    required: [:name, :image_url]
+
+  setup_all do
+    {:ok, fundamentals: get_json()}
+  end
+
+  describe "fundamentals JSON validation" do
+    test "validates priv/repo/data/fundamentals.json file", %{fundamentals: fundamentals} do
+      assert Enum.all?(fundamentals, &validate/1)
+    end
+  end
+end

--- a/test/techschool/languages_json_test.exs
+++ b/test/techschool/languages_json_test.exs
@@ -1,0 +1,21 @@
+defmodule Techschool.LanguagesJSONTest do
+  use ExUnit.Case
+
+  use Techschool.JSONValidator,
+    path: "priv/repo/data/languages.json",
+    types: %{
+      name: :string,
+      image_url: :string
+    },
+    required: [:name]
+
+  setup_all do
+    {:ok, languages: get_json()}
+  end
+
+  describe "languages JSON validation" do
+    test "validates priv/repo/data/languages.json file", %{languages: languages} do
+      assert Enum.all?(languages, &validate/1)
+    end
+  end
+end

--- a/test/techschool/lessons_json_test.exs
+++ b/test/techschool/lessons_json_test.exs
@@ -1,0 +1,28 @@
+defmodule Techschool.LessonsJSONTest do
+  use ExUnit.Case
+
+  use Techschool.JSONValidator,
+    path: "priv/repo/data/lessons.json",
+    types: %{
+      name: :string,
+      optional: :boolean,
+      image_url: :string,
+      description_en: :string,
+      description_pt: :string,
+      language_names: :string,
+      framework_names: :string,
+      tool_names: :string,
+      fundamentals_names: :string
+    },
+    required: [:name, :optional, :image_url, :description_en, :description_pt]
+
+  setup_all do
+    {:ok, lessons: get_json()}
+  end
+
+  describe "lessons JSON validation" do
+    test "validates priv/repo/data/lessons.json file", %{lessons: lessons} do
+      assert Enum.all?(lessons, &validate/1)
+    end
+  end
+end

--- a/test/techschool/platforms_json_test.exs
+++ b/test/techschool/platforms_json_test.exs
@@ -1,0 +1,28 @@
+defmodule Techschool.PlatformsJSONTest do
+  use ExUnit.Case
+
+  use Techschool.JSONValidator,
+    path: "priv/repo/data/platforms.json",
+    types: %{
+      name: :string,
+      description_en: :string,
+      description_pt: :string,
+      url: :string,
+      image_url: :string,
+      language_names: {:array, :string},
+      framework_names: {:array, :string},
+      tool_names: {:array, :string},
+      fundamentals_names: {:array, :string}
+    },
+    required: [:name, :description_en, :description_pt, :image_url, :url]
+
+  setup_all do
+    {:ok, platforms: get_json()}
+  end
+
+  describe "platforms JSON validation" do
+    test "validates priv/repo/data/platforms.json file", %{platforms: platforms} do
+      assert Enum.all?(platforms, &validate/1)
+    end
+  end
+end

--- a/test/techschool/tools_json_test.exs
+++ b/test/techschool/tools_json_test.exs
@@ -1,0 +1,21 @@
+defmodule Techschool.ToolsJSONTest do
+  use ExUnit.Case
+
+  use Techschool.JSONValidator,
+    path: "priv/repo/data/tools.json",
+    types: %{
+      name: :string,
+      image_url: :string
+    },
+    required: [:name, :image_url]
+
+  setup_all do
+    {:ok, tools: get_json()}
+  end
+
+  describe "tools JSON validation" do
+    test "validates priv/repo/data/tools.json file", %{tools: tools} do
+      assert Enum.all?(tools, &validate/1)
+    end
+  end
+end


### PR DESCRIPTION
## Why is this change being made?
resolves #78

## How is this being accomplished?
1. A module to `use`, providing Ecto schemaless types for each JSON file
2. assert that each object in the file is a `valid?: true` Ecto changeset.

Some caveats I wanted to note:
- `cast`ing will not catch a typo like "names" instead of "name". It simply won't include those properties in the changes.
- You can perform required validations through the `required` argument when `use`ing the module. This is the main validation I included and consulted the schemas as to what fields should be required.
- If needed, you can override the `validate/1` function in a test file. For example, if you needed or wanted to perform additional validations on the changeset for that particular test file.
