### PR TITLE
feat: add ash framework and one ash playlist

### DIFF
--- a/lib/techschool_web/components/shared_components.ex
+++ b/lib/techschool_web/components/shared_components.ex
@@ -1534,6 +1534,29 @@ defmodule TechschoolWeb.SharedComponents do
         </svg>
         """
 
+      "ash" ->
+        ~H"""
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="123"
+          height="100"
+          viewBox="0 0 123 100"
+          fill="none"
+          {@rest}
+        >
+          <path d="M61.1819 0L122.364 100H119.033L44.1681 27.8086L61.1819 0Z" fill="#FF5757" />
+          <path
+            d="M22.2352 100H29.4163L67.9877 53.5421L43.6726 30.0954L22.2352 100Z"
+            fill="#FF914D"
+          />
+          <path d="M52.3575 100H32.0029L52.7027 75.0678L52.3575 100Z" fill="#FFBD59" />
+          <path d="M54.3478 100H91.6425L54.725 72.7514L54.3478 100Z" fill="#FF5757" />
+          <path d="M95.8815 100L70.8665 56.3181L116.166 100H95.8815Z" fill="#FF914D" />
+          <path d="M92.5593 98.2033L55.9368 71.1724L68.4492 56.1016L92.5593 98.2033Z" fill="#FFBD59" />
+          <path d="M20.1537 100H0L40.4074 33.9553L20.1537 100Z" fill="#FFBD59" />
+        </svg>
+        """
+
       _ ->
         ~H""
     end

--- a/lib/techschool_web/components/shared_components.ex
+++ b/lib/techschool_web/components/shared_components.ex
@@ -3,7 +3,7 @@ defmodule TechschoolWeb.SharedComponents do
 
   attr :name, :string,
     values:
-      ~w(github discord heart analytics logo c javascript css elixir gleam golang html java liquid php python ruby typescript algorithms computer-science networking programming docker git linux sql shopify angular django express godot laravel nest next node phoenix rails react remix spring tailwind vue react-router)
+      ~w(github discord heart analytics logo c javascript css elixir gleam golang html java liquid php python ruby typescript algorithms computer-science networking programming docker git linux sql shopify angular django express godot laravel nest next node phoenix rails react remix spring tailwind vue react-router ash)
 
   attr :rest, :global, doc: "the arbitrary HTML attributes to add to the svg"
 

--- a/lib/techschool_web/live/page_live/components/programming-languages-grid.html.heex
+++ b/lib/techschool_web/live/page_live/components/programming-languages-grid.html.heex
@@ -74,6 +74,14 @@
 
   <.link
     class="flex items-center gap-2 bg-slate-800/30 backdrop-blur-sm rounded-full px-3 py-1 border border-green/20 hover:border-green transition-colors"
+    navigate={~p"/#{@locale}/courses?framework=ash"}
+  >
+    <.custom_icon name="ash" class="w-4 h-4" />
+    <span class="text-xs text-gray-300">Ash</span>
+  </.link>
+
+  <.link
+    class="flex items-center gap-2 bg-slate-800/30 backdrop-blur-sm rounded-full px-3 py-1 border border-green/20 hover:border-green transition-colors"
     navigate={~p"/#{@locale}/courses"}
   >
     <span class="text-xs text-gray-300">{gettext("Much more")}</span>

--- a/priv/repo/data/courses.json
+++ b/priv/repo/data/courses.json
@@ -1699,5 +1699,14 @@
     "framework_names": [],
     "tool_names": [],
     "fundamentals_names": []
+  },
+  {
+    "name": "Ash Framework SaaS Masterclass",
+    "youtube_course_id": "PL2Rv8vpZJz4xfqYRlkO3IPg8uBuuHccwf",
+    "locale": "en",
+    "language_names": [],
+    "framework_names": ["Ash"],
+    "tool_names": [],
+    "fundamentals_names": []
   }
 ]

--- a/priv/repo/data/frameworks.json
+++ b/priv/repo/data/frameworks.json
@@ -54,5 +54,9 @@
   {
     "name": "Godot",
     "icon_name": "godot"
+  },
+  {
+    "name": "Ash",
+    "icon_name": "ash" 
   }
 ]


### PR DESCRIPTION
Add [Ash Framework SaaS Masterclass](https://www.youtube.com/watch?v=zM_-Y4diVFw&list=PL2Rv8vpZJz4xfqYRlkO3IPg8uBuuHccwf) course (as a youtube playlist)

Add Ash Framework

Add Ash logo in homepage

<img width="911" height="590" alt="image" src="https://github.com/user-attachments/assets/f045f12c-d6d2-468f-9d9f-9b538c59143d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added Ash framework to the catalog with a dedicated icon.
  * Introduced an Ash link in the programming languages grid for quick access.
  * Published a new course: “Ash Framework SaaS Masterclass” (EN), now available in the courses list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->